### PR TITLE
Add systemd/cgroups slice option

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ manage_group_users
 
 - *Default*: 'undef'
 
+manage_containerd
+-----------------
+
+- *Default*: false
+
 images
 ------
 
@@ -116,3 +121,12 @@ exceptions
 ----------
 
 - *Default*: 'undef'
+
+===
+
+# class docker::conf::slice
+
+systemd_slice
+-------------
+
+- *Default*: undef

--- a/manifests/conf/slice.pp
+++ b/manifests/conf/slice.pp
@@ -1,0 +1,34 @@
+# == Class: docker::conf:slice
+#
+# Configure systemd resource slice for docker
+#
+class docker::conf::slice (
+  $systemd_slice = undef,
+) {
+  if $systemd_slice != undef {
+    validate_string($systemd_slice)
+
+    file { 'docker_slice_conf':
+      ensure  => present,
+      path    => '/etc/systemd/system/docker.service.d/slice.conf',
+      content => template('docker/slice.conf.erb'),
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0644',
+      require => File['etc_docker_service_d_dir'],
+      notify  => Exec['systemd_reload'],
+    }
+    if $docker::manage_containerd_real {
+      file { 'containerd_slice_conf':
+        ensure  => present,
+        path    => '/etc/systemd/system/containerd.service.d/slice.conf',
+        content => template('docker/slice.conf.erb'),
+        owner   => 'root',
+        group   => 'root',
+        mode    => '0644',
+        require => File['etc_containerd_service_d_dir'],
+        notify  => Exec['systemd_reload'],
+      }
+    }
+  }
+}

--- a/templates/slice.conf.erb
+++ b/templates/slice.conf.erb
@@ -1,2 +1,2 @@
 [Service]
-Slice="<%= @systemd_slice %>"
+Slice=<%= @systemd_slice %>

--- a/templates/slice.conf.erb
+++ b/templates/slice.conf.erb
@@ -1,0 +1,2 @@
+[Service]
+Slice="<%= @systemd_slice %>"


### PR DESCRIPTION
When not set docker creates a user.slice with cpuacc on in RH7.
This breaks kernel.sched_autogroup_enabled=1 which relies on placing
new sessions (setsid) in their own groups outside of cgroup.

This commit enable the user to set which slice docker and containerd will
start in i.e. machine.slice (same as systemd-nspawn).